### PR TITLE
Include LICENSE file in package and specifiy license in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ exclude *
 recursive-exclude * *
 
 include MANIFEST.in
+include LICENSE
 include setup.py
 
 graft src/django_secret_sharing

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     include_package_data=True,
+    license="MIT",
     zip_safe=False,
     classifiers=[
         "Environment :: Web Environment",


### PR DESCRIPTION
We use a license checker to scan for the licenses of packages we use. This package results in UNKNOWN.

While the package has a LICENSE file:
https://github.com/vicktornl/django-secret-sharing/blob/master/LICENSE

It's not included in the package itself. Neither is the LICENSE defined in setup.py

This PR solves LICENSE not being available based on package data by adding the LICENSE file to the package data and adding it to the setup.py